### PR TITLE
Fix rbbox_overlaps kernel

### DIFF
--- a/libs/box_utils/rbbox_overlaps_kernel.cu
+++ b/libs/box_utils/rbbox_overlaps_kernel.cu
@@ -153,7 +153,7 @@ __device__ inline bool inrect(float pt_x, float pt_y, float * pts) {
   abap = ab[0] * ap[0] + ab[1] * ap[1];
   adad = ad[0] * ad[0] + ad[1] * ad[1];
   adap = ad[0] * ap[0] + ad[1] * ap[1];
-  bool result = (abab - abap >=  -1) and (abap >= -1) and (adad - adap >= -1) and (adap >= -1);
+  bool result = (abab >= abap) and (abap >= 0) and (adad >= adap) and (adap >= 0);
   return result;
 }
 


### PR DESCRIPTION
Hi,

I am working on a custom skew IOU kernel for tensorflow (https://github.com/fellhorn/tensorflow_rotated_iou_op) to be used in my master thesis.

And I think I found an error how you calculate the point in rectangle check. You actually have the correct code in `libs/box_utils/rotate_polygon_nms_kernel.cu`, so I think it should look the same in the rbbox_overlaps kernel.

Thanks a lot for your repo and keep up the great work :)